### PR TITLE
Retryable.disable!

### DIFF
--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -1,3 +1,4 @@
+require 'retryable/config'
 
 module Kernel
   class InvalidRetryableOptions < RuntimeError; end
@@ -15,6 +16,7 @@ module Kernel
     begin
       return yield retries
     rescue *retry_exception => exception
+      raise unless Retryable::Config.instance.allow_retry
       raise unless exception.message =~ opts[:matching]
       raise if retries+1 >= opts[:tries]
       sleep opts[:sleep].respond_to?(:call) ? opts[:sleep].call(retries) : opts[:sleep]

--- a/lib/retryable/config.rb
+++ b/lib/retryable/config.rb
@@ -1,0 +1,19 @@
+require 'singleton'
+
+module Retryable
+  class Config
+    include Singleton
+    attr_accessor :allow_retry
+  end
+  
+  def self.enable!
+    Config.instance.allow_retry = true
+  end
+  
+  def self.disable!
+    Config.instance.allow_retry = false
+  end
+end
+
+# Set defaults
+Retryable.enable!

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe 'retryable' do
 
-  before(:each) do
-    @attempt = 0
-  end
-
   it "should retry on default exception" do
     Kernel.should_receive(:sleep).once.with(1)
 
@@ -73,14 +69,22 @@ describe 'retryable' do
       retryable(:bad_option => 2) { raise "this is bad" }
     end.should raise_error InvalidRetryableOptions
   end
+  
+end
 
-  private
-
-  def count_retryable *opts
-    @try_count = 0
-    return Kernel.retryable(*opts) do |*args|
-      @try_count += 1
-      yield *args
-    end
+describe 'retryable disabled' do
+  
+  around(:each) do |example|
+    Retryable.disable!
+    example.run
+    Retryable.enable!
   end
+  
+  it "should not retry if disabled" do
+    lambda do
+      count_retryable(:tries => 2) { raise }
+    end.should raise_error RuntimeError
+    @try_count.should == 1
+  end
+  
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + '/../lib/retryable'
 require 'rspec'
 
@@ -6,4 +5,12 @@ RSpec.configure do |config|
   # Remove this line if you don't want RSpec's should and should_not
   # methods or matchers
   require 'rspec/expectations'
+end
+
+def count_retryable *opts
+  @try_count = 0
+  return Kernel.retryable(*opts) do |*args|
+    @try_count += 1
+    yield *args
+  end
 end


### PR DESCRIPTION
This allows you to globally disable retries and raise in the normal fashion.  This is useful, e.g. for test environment where you might want errors to be raised but not want to sit through the sleep loops.
