### PR TITLE
Not option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Description
 Runs a code block, and retries it when an exception occurs. It's great when
 working with flakey webservices (for example).
 
-It's configured using five optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception_cb`, ':not' and
+It's configured using five optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception_cb`, `:not` and
 runs the passed block. Should an exception occur, it'll retry for (n-1) times.
 
 Should the number of retries be reached without success, the last exception

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Description
 Runs a code block, and retries it when an exception occurs. It's great when
 working with flakey webservices (for example).
 
-It's configured using four optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception_cb` and
+It's configured using five optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception_cb`, ':not' and
 runs the passed block. Should an exception occur, it'll retry for (n-1) times.
 
 Should the number of retries be reached without success, the last exception
@@ -56,7 +56,7 @@ end
 
 ## Defaults
 
-    :tries => 2, :on => StandardError, :sleep => 1, :matching  => /.*/, :ensure => Proc.new { }, :exception_cb => Proc.new { }
+    :tries => 2, :on => StandardError, :sleep => 1, :matching  => /.*/, :ensure => Proc.new { }, :exception_cb => Proc.new { }, :not => []
 
 Retryable also could be configured globally to change those defaults:
 
@@ -68,6 +68,7 @@ Retryable.configure do |config|
   config.on           = StandardError
   config.sleep        = 1
   config.tries        = 2
+  config.not          = []
 end
 ```
 
@@ -128,6 +129,20 @@ Retryable.disable
 
 Retryable.enabled?
 => false
+```
+
+Specify exceptions where a retry should NOT be performed
+--------
+No more tries will be made if an exception listed in `:not` is raised.
+Takes precedence over `:on`.
+
+```
+class MyError < StandardError; end
+
+Retryable.retryable(:tries => 5, :on => [StandardError], :not => [MyError]) do
+  raise MyError "No retries!"
+end
+
 ```
 
 Supported Ruby Versions

--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -17,7 +17,7 @@ module Retryable
     #     config.on           = StandardError
     #     config.sleep        = 1
     #     config.tries        = 2
-    #     config.not          = RuntimeError
+    #     config.not          = []
     #   end
     def configure
       yield(configuration)

--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -17,6 +17,7 @@ module Retryable
     #     config.on           = StandardError
     #     config.sleep        = 1
     #     config.tries        = 2
+    #     config.not          = RuntimeError
     #   end
     def configure
       yield(configuration)
@@ -47,7 +48,8 @@ module Retryable
         :on           => self.configuration.on,
         :matching     => self.configuration.matching,
         :ensure       => self.configuration.ensure,
-        :exception_cb => self.configuration.exception_cb
+        :exception_cb => self.configuration.exception_cb,
+        :not          => self.configuration.not
       }
 
       check_for_invalid_options(options, opts)
@@ -55,12 +57,16 @@ module Retryable
 
       return if opts[:tries] == 0
 
-      on_exception, tries = [ opts[:on] ].flatten, opts[:tries]
+      on_exception = [ opts[:on] ].flatten
+      not_exception = [ opts[:not] ].flatten
+      tries = opts[:tries]
       retries = 0
       retry_exception = nil
 
       begin
         return yield retries, retry_exception
+      rescue *not_exception
+        raise
       rescue *on_exception => exception
         raise unless configuration.enabled?
         raise unless exception.message =~ opts[:matching]
@@ -69,6 +75,8 @@ module Retryable
         # Interrupt Exception could be raised while sleeping
         begin
           Kernel.sleep opts[:sleep].respond_to?(:call) ? opts[:sleep].call(retries) : opts[:sleep]
+        rescue *not_exception
+          raise
         rescue *on_exception
         end
 
@@ -90,4 +98,3 @@ module Retryable
     end
   end
 end
-

--- a/lib/retryable/configuration.rb
+++ b/lib/retryable/configuration.rb
@@ -7,7 +7,8 @@ module Retryable
       :matching,
       :on,
       :sleep,
-      :tries
+      :tries,
+      :not
     ].freeze
 
     attr_accessor :ensure
@@ -16,6 +17,7 @@ module Retryable
     attr_accessor :on
     attr_accessor :sleep
     attr_accessor :tries
+    attr_accessor :not
 
     attr_accessor :enabled
 
@@ -28,6 +30,7 @@ module Retryable
       @on           = StandardError
       @sleep        = 1
       @tries        = 2
+      @not          = []
 
       @enabled     = true
     end

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Retryable.retryable' do
   
   it 'gives precidence for :not over :on' do
     expect do
-      count_retryable(:sleep => 0, :tries => 3, :on => StandardError, :not => IndexError ) { |tries| raise tries >= 1 ? IndexError : StandardError}
+      count_retryable(:sleep => 0, :tries => 3, :on => StandardError, :not => IndexError ) { |tries| raise tries >= 1 ? IndexError : StandardError }
     end.to raise_error IndexError
     expect(@try_count).to eq(2)
   end

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Retryable.retryable' do
   
   it 'gives precidence for :not over :on' do
     expect do
-      count_retryable(:sleep => 0, :tries => 3, :on => StandardError, :not => IndexError ) { |tries| raise tries >= 1 ? IndexError : StandardError }
+      count_retryable(:sleep => 0, :tries => 3, :on => StandardError, :not => IndexError ) { |tries, ex| raise tries >= 1 ? IndexError : StandardError }
     end.to raise_error IndexError
     expect(@try_count).to eq(2)
   end

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -115,4 +115,18 @@ RSpec.describe 'Retryable.retryable' do
 
     expect(@raised).to eq("this is fun!")
   end
+  
+  it 'does not retry on :not exception' do
+    expect do
+      count_retryable(:not => RuntimeError ) { |tries, ex| raise RuntimeError if tries < 1 }
+    end.to raise_error RuntimeError
+    expect(@try_count).to eq(1)
+  end
+  
+  it 'gives precidence for :not over :on' do
+    expect do
+      count_retryable(:sleep => 0, :tries => 3, :on => StandardError, :not => IndexError ) { |tries| raise tries >= 1 ? IndexError : StandardError}
+    end.to raise_error IndexError
+    expect(@try_count).to eq(2)
+  end
 end


### PR DESCRIPTION
This PR adds the :not option to Retryables. 

The idea is that errors specified in :not take priority over those specified in :on. This is useful for scenarios where, for instance, you retry on StandardError by default, but in some instances you do NOT want to retry if it's an IndexError (IndexError < StandardError).

