### PR TITLE
test against Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.0
   - rbx-2
   - ruby-head
 matrix:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ versions:
 * Ruby 2.0.0
 * Ruby 2.1.2
 * Ruby 2.2.0
+* Ruby 2.3.1
+* Ruby 2.4.0
 
 If something doesn't work on one of these versions, it's a bug.
 


### PR DESCRIPTION
Ruby 2.4 has already been released. All tests seem to pass with Ruby 2.4, so I think it is good to add Ruby 2.4 to CI. How about that?