### PR TITLE
Replace flatten to Object#is_a?

### DIFF
--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -60,8 +60,8 @@ module Retryable
 
       return if opts[:tries] == 0
 
-      on_exception = [opts[:on]].flatten
-      not_exception = [opts[:not]].flatten
+      on_exception = opts[:on].is_a?(Array) ? opts[:on] : [opts[:on]]
+      not_exception = opts[:not].is_a?(Array) ? opts[:not] : [opts[:not]]
       tries = opts[:tries]
       retries = 0
       retry_exception = nil

--- a/spec/retryable_spec.rb
+++ b/spec/retryable_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe Retryable do
       expect(counter.count).to eq(2)
     end
 
+    it 'does not retry on :not exception which is covered by Array' do
+      expect do
+        counter(not: [RuntimeError, IndexError]) { |tries| raise RuntimeError if tries < 1 }
+      end.to raise_error RuntimeError
+      expect(counter.count).to eq(1)
+    end
+
     it 'does not try on unexpected exception' do
       allow(Kernel).to receive(:sleep)
       expect do


### PR DESCRIPTION
Hi, I compare using `flatten` and using `is_a`? Using `is_a?` is faster than `flatten`.

```
Warming up --------------------------------------
             flatten     1.869k i/s
      using Array.[]    56.587k i/s
        Object#is_a?    16.534M i/s
Calculating -------------------------------------
             flatten     2.029k i/s -      5.607k times in 2.763675s (492.90μs/i)
      using Array.[]    54.798k i/s -    169.760k times in 3.097910s (18.25μs/i)
        Object#is_a?    30.039M i/s -     49.602M times in 1.651260s (33.29ns/i)

Comparison:
        Object#is_a?:  30038651.1 i/s 
      using Array.[]:     54798.2 i/s - 548.17x  slower
             flatten:      2028.8 i/s - 14805.97x  slower
```

```ruby
require 'benchmark_driver'

Benchmark.driver do |x|
  x.prelude %{ array = [*1..5000] }
  x.report "flatten", %{ [array].flatten }
  x.report "using Array.[]", %{ Array[*array] }
  x.report "Object#is_a?", %{ array.is_a?(Array) ? array : [array] }
  x.compare!
end
```