### PR TITLE
add-exception-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Description
 Runs a code block, and retries it when an exception occurs. It's great when
 working with flakey webservices (for example).
 
-It's configured using several optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception_cb`, `:not`, `:sleep_method` and
+It's configured using several optional parameters `:tries`, `:on`, `:sleep`, `:matching`, `:ensure`, `:exception`, `:exception_cb`, `:not`, `:sleep_method` and
 runs the passed block. Should an exception occur, it'll retry for (n-1) times.
 
 Should the number of retries be reached without success, the last exception
@@ -84,6 +84,7 @@ end
 
     contexts: {},
     ensure: proc { },
+    exception: true,
     exception_cb: proc { },
     log_method: proc { },
     matching : /.*/,
@@ -99,6 +100,7 @@ Retryable also could be configured globally to change those defaults:
 Retryable.configure do |config|
   config.contexts     = {}
   config.ensure       = proc {}
+  config.exception    = true
   config.exception_cb = proc {}
   config.log_method   = proc {}
   config.matching     = /.*/
@@ -110,6 +112,18 @@ Retryable.configure do |config|
 end
 ```
 
+Raise or not when give up
+-------
+By default Retryable raise error after retry `:tries` times.
+You can change to retrun `nil` with `exception: false`
+
+```ruby
+Retryable.retryable(tries: 3) { raise }
+# => raise
+
+Retryable.retryable(tries: 3, exception: false) { raise }
+# => nil
+```
 
 Sleeping
 --------

--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -75,7 +75,10 @@ module Retryable
       rescue *on_exception => exception
         raise unless configuration.enabled?
         raise unless matches?(exception.message, matching)
-        raise if tries != :infinite && retries + 1 >= tries
+        if tries != :infinite && retries + 1 >= tries
+          raise if opts[:exception]
+          return
+        end
 
         # Interrupt Exception could be raised while sleeping
         begin

--- a/lib/retryable/configuration.rb
+++ b/lib/retryable/configuration.rb
@@ -4,6 +4,7 @@ module Retryable
     VALID_OPTION_KEYS = [
       :contexts,
       :ensure,
+      :exception,
       :exception_cb,
       :log_method,
       :matching,
@@ -21,6 +22,7 @@ module Retryable
     def initialize
       @contexts     = {}
       @ensure       = proc {}
+      @exception    = true
       @exception_cb = proc {}
       @log_method   = proc {}
       @matching     = /.*/

--- a/spec/retryable_spec.rb
+++ b/spec/retryable_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Retryable do
       expect(counter.count).to eq(3)
     end
 
+    it 'does not raise exception when exception: false' do
+      expect do
+        counter(tries: 3, exception: false) { raise StandardError }
+      end.not_to raise_error
+    end
+
     it 'retries infinitely' do
       expect do
         Timeout.timeout(3) do


### PR DESCRIPTION
it makes easy to give up and continue

Naming of `exception` is a semi-standard name after ruby-2.6.0
https://bugs.ruby-lang.org/issues/12732
https://bugs.ruby-lang.org/issues/14386