### PR TITLE
Fix native logger example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,11 @@ end
 
 If you prefer to use Rails' native logger:
 
+```ruby
 log_method = lambda do |retries, exception|
   Rails.logger.debug("[Attempt ##{retries}] Retrying because [#{exception.class} - #{exception.message}]: #{exception.backtrace.first(5).join(' | ')}")
 end
+```
 
 Contexts
 --------


### PR DESCRIPTION
Fixes the formatting of the Rails native logger example by wrapping it in a Markdown code block.