### PR TITLE
Fix exception message when invalid matching.

### DIFF
--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -113,7 +113,7 @@ module Retryable
         when Regexp
           message =~ candidate
         else
-          raise ArgumentError, ':matches must be a string or regex'
+          raise ArgumentError, ':matching must be a string or regex'
         end
       end
     end

--- a/spec/retryable_spec.rb
+++ b/spec/retryable_spec.rb
@@ -134,6 +134,12 @@ RSpec.describe Retryable do
       expect(counter.count).to eq(4)
     end
 
+    it 'does not allow invalid type of matching option' do
+      expect do
+        described_class.retryable(matching: 1) { raise 'this is invaid type of matching iotion' }
+      end.to raise_error ArgumentError, ':matching must be a string or regex'
+    end
+
     it 'does not allow invalid options' do
       expect do
         described_class.retryable(bad_option: 2) { raise 'this is bad' }


### PR DESCRIPTION
exception message is a bit confusing for developer when option `matching` is invalid type.

exception message is following:

```
 #=> :matches must be a string or regex (ArgumentError)
```

it is a bit confusing because of no `matches` options.

```ruby
Retryable.retryable(
  matching: 1 # invalid type
) do |retries, exception|
  raise StandardError, "test"
end
```

