### PR TITLE
Clean up infinite retries parsing.

### DIFF
--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -76,8 +76,8 @@ module Retryable
         raise unless configuration.enabled?
         raise unless matches?(exception.message, matching)
 
-        infinite_retries = :infinite || tries.respond_to?(:infinite?) && tries.infinite?
-        raise if tries != infinite_retries && retries + 1 >= tries
+        infinite_retries = tries == :infinite || tries.respond_to?(:infinite?) && tries.infinite? == 1
+        raise if !infinite_retries && retries + 1 >= tries
 
         # Interrupt Exception could be raised while sleeping
         begin


### PR DESCRIPTION
The original `:infinite || tries.respond_to?(:infinite?) && tries.infinite?` is always `:infinite`.