### PR TITLE
Add a retries option as an alternative to the tries option

### DIFF
--- a/lib/retryable.rb
+++ b/lib/retryable.rb
@@ -54,6 +54,7 @@ module Retryable
 
       check_for_invalid_options(options, opts)
       opts.merge!(options)
+      opts[:tries] = opts[:retries] + 1 if opts[:retries]
 
       # rubocop:disable Style/NumericPredicate
       return if opts[:tries] == 0

--- a/lib/retryable/configuration.rb
+++ b/lib/retryable/configuration.rb
@@ -11,7 +11,8 @@ module Retryable
       :on,
       :sleep,
       :sleep_method,
-      :tries
+      :tries,
+      :retries
     ].freeze
 
     attr_accessor(*VALID_OPTION_KEYS)

--- a/spec/retryable_spec.rb
+++ b/spec/retryable_spec.rb
@@ -72,10 +72,16 @@ RSpec.describe Retryable do
       expect(counter.count).to eq(1)
     end
 
-    it 'retries three times' do
+    it 'tries three times when "tries" option is set to 3' do
       allow(Kernel).to receive(:sleep)
       counter(tries: 3) { |tries| raise StandardError if tries < 2 }
       expect(counter.count).to eq(3)
+    end
+
+    it 'tries four times when "retries" option is set to 3' do
+      allow(Kernel).to receive(:sleep)
+      counter(retries: 3) { |tries| raise StandardError if tries < 3 }
+      expect(counter.count).to eq(4)
     end
 
     context 'infinite retries' do


### PR DESCRIPTION
Thanks for maintaining this cool gem!

Sometimes I prefer to think in terms of `retries` instead of `tries`. As in, "retry this code 3 times". This PR adds an optional `retries` option that does just that:

```ruby
Retryable.retryable(retries: 3) { ... } # Retry 3 times, a.k.a try 4 times
```

This is just "syntactic sugar" as under the hood it just sets `tries` to `retries + 1`. But if you want to think in terms of retries, then I think this is a pretty useful option.