### PR TITLE
Introduce GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,9 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
         continue-on-error: ${{ matrix.ruby == 'head' }}
+      - uses: paambaati/codeclimate-action@v3.0.0
+        if: ${{ matrix.ruby == '2.7' }} # 3.0 is failed due to the old json gem's version
+        with:
+          coverageLocations: '${{ github.workspace }}/coverage/coverage.json:simplecov'
+        env:
+          CC_TEST_REPORTER_ID: 3e6be56b2a7bbe02b05521f6d8014aa13e2e0809b485e5f0a21551879a756b20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['**']
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: [1.9, '2.0', 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake
+        continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ group :development do
 end
 
 group :test do
-  gem 'codeclimate-test-reporter'
   gem 'rspec', '~> 3.1'
   gem 'simplecov', require: false
+  gem 'simplecov_json_formatter', require: false
 end
 
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ require 'simplecov'
 Dir.glob(File.expand_path('../support/**/*.rb', __FILE__), &method(:require))
 # rubocop:enable Style/ExpandPathArguments
 
+if ENV['CI']
+  require 'simplecov_json_formatter'
+  SimpleCov.formatter = SimpleCov::Formatter::JSONFormatter
+end
+
 SimpleCov.start
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR aims to introduce GitHub Actions for CI which will be replaced with TravisCI.

https://github.com/nfedyashev/retryable/blob/3cf890e1247bd767d8e70398cd51715d7441744e/.travis.yml#L1

Since I'm not sure about the CodeClimate setup, so this change doesn't include its settings.
But please tell me if you'd like to include it!

See also:
- https://github.com/ruby/setup-ruby
- https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
