### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # TODO restore 2.2 once RubyGems issue is resolved?
-        ruby: ['1.9', '2.0', '2.1', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3.0-preview1', head]
+        ruby: ['1.9', '2.0', '2.1', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', head]
     runs-on: ${{ matrix.os }}
     env:
       BUNDLE_WITHOUT: development


### PR DESCRIPTION
[setup-ruby now supports Ruby 3.3.0!](https://github.com/ruby/setup-ruby/pull/553) Added Ruby 3.3 to the test matrix.